### PR TITLE
Add support for udp and tcp Graphite protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Currently it has two flavors:
 1. Docker image which reads JMX from a jolokia agent running on a JVM, since exposing JMX is the simplest and easiest through Jolokia agent (1 liner - see below).
 2. Run as a java agent, and get metrics directly from MBean Platform
 
-The reporting to graphite is done through the Pickle protocol, hence by default port 2004, since it's more efficient.
-
 The metrics reported have the following names template:
 
 [service-name].[service-host].[metric-name]
@@ -51,7 +49,8 @@ there are two ways to specify the host in the jolokia URL so this URL will be re
 
 ### Optional environment variables
 
-- GRAPHITE_PORT: *Pickle* protocol port of graphite. Defaults to 2004. Don't use the text protocol port (2003) otherwise it wouldn't work.
+- GRAPHITE_PORT: Protocol port of graphite. Defaults to 2004.
+- GRAPHITE_PROTOCOL: Protocol for graphite communication. Defaults to "pickle". Possible values: udp, tcp, pickle
 - SERVICE_HOST: By default the host is taken from Jolokia URL and serves as the service host, unless you use this variable.
 - INTERVAL_IN_SEC: By default 30 seconds unless you use this variable.
 

--- a/src/dist/conf/application.conf
+++ b/src/dist/conf/application.conf
@@ -20,6 +20,7 @@ service {
 graphite {
   hostname = ${GRAPHITE_HOST}
   port = ${?GRAPHITE_PORT}
+  protocol = ${?GRAPHITE_PROTOCOL}
 }
 
 metricsPollingIntervalInSeconds = ${?INTERVAL_IN_SEC}

--- a/src/main/java/io/logz/jmx2graphite/GraphiteClient.java
+++ b/src/main/java/io/logz/jmx2graphite/GraphiteClient.java
@@ -1,5 +1,8 @@
 package io.logz.jmx2graphite;
 
+import static io.logz.jmx2graphite.GraphiteProtocol.TCP;
+import static io.logz.jmx2graphite.GraphiteProtocol.UDP;
+
 import com.codahale.metrics.graphite.Graphite;
 import com.codahale.metrics.graphite.GraphiteSender;
 import com.codahale.metrics.graphite.GraphiteUDP;
@@ -25,7 +28,7 @@ public class GraphiteClient implements Closeable {
 
     public GraphiteClient(String serviceHost, String serviceName, String graphiteHostname, int graphitePort,
                           int connectTimeout, int socketTimeout, int writeTimeoutMs,
-                          String protocol) {
+                          GraphiteProtocol protocol) {
         List<String> prefixElements = Lists.newArrayList();
         if (serviceName != null && !serviceName.isEmpty()) {
             prefixElements.add(sanitizeMetricName(serviceName));
@@ -43,9 +46,9 @@ public class GraphiteClient implements Closeable {
         logger.info("Graphite Client: using writeTimeoutMs of {} [ms]. Establishing connection..." ,writeTimeoutMs);
 
         SocketFactory socketFactory = new SocketFactoryWithTimeouts(connectTimeout, socketTimeout);
-        if ("udp".equals(protocol)) {
+        if (protocol == UDP) {
             graphite = new GraphiteUDP(new InetSocketAddress(graphiteHostname, graphitePort));
-        } else if ("tcp".equals(protocol)) {
+        } else if (protocol == TCP) {
             graphite = new Graphite(new InetSocketAddress(graphiteHostname, graphitePort),
                                     socketFactory);
         } else {

--- a/src/main/java/io/logz/jmx2graphite/GraphiteProtocol.java
+++ b/src/main/java/io/logz/jmx2graphite/GraphiteProtocol.java
@@ -1,0 +1,10 @@
+package io.logz.jmx2graphite;
+
+/**
+ * Supported Graphite protocols.
+ */
+public enum GraphiteProtocol {
+
+  UDP, TCP, PICKLED
+
+}

--- a/src/main/java/io/logz/jmx2graphite/Jmx2GraphiteConfiguration.java
+++ b/src/main/java/io/logz/jmx2graphite/Jmx2GraphiteConfiguration.java
@@ -31,9 +31,9 @@ public class Jmx2GraphiteConfiguration {
 
     // Which client should we use
     private MetricClientType metricClientType;
-    private String graphiteProtocol;
+    private GraphiteProtocol graphiteProtocol;
 
-    public String getGraphiteProtocol() {
+    public GraphiteProtocol getGraphiteProtocol() {
         return graphiteProtocol;
     }
 
@@ -95,7 +95,7 @@ public class Jmx2GraphiteConfiguration {
 
         graphiteConnectTimeout = config.getInt("graphite.connectTimeout");
         graphiteSocketTimeout = config.getInt("graphite.socketTimeout");
-        graphiteProtocol = config.getString("graphite.protocol");
+        graphiteProtocol = GraphiteProtocol.valueOf(config.getString("graphite.protocol"));
         if (config.hasPath("graphite.writeTimeout")) {
             graphiteWriteTimeoutMs = config.getInt("graphite.writeTimeout");
         } else {

--- a/src/main/java/io/logz/jmx2graphite/Jmx2GraphiteConfiguration.java
+++ b/src/main/java/io/logz/jmx2graphite/Jmx2GraphiteConfiguration.java
@@ -31,6 +31,11 @@ public class Jmx2GraphiteConfiguration {
 
     // Which client should we use
     private MetricClientType metricClientType;
+    private String graphiteProtocol;
+
+    public String getGraphiteProtocol() {
+        return graphiteProtocol;
+    }
 
     public enum MetricClientType {
         JOLOKIA,
@@ -90,6 +95,7 @@ public class Jmx2GraphiteConfiguration {
 
         graphiteConnectTimeout = config.getInt("graphite.connectTimeout");
         graphiteSocketTimeout = config.getInt("graphite.socketTimeout");
+        graphiteProtocol = config.getString("graphite.protocol");
         if (config.hasPath("graphite.writeTimeout")) {
             graphiteWriteTimeoutMs = config.getInt("graphite.writeTimeout");
         } else {

--- a/src/main/java/io/logz/jmx2graphite/Jmx2GraphiteConfiguration.java
+++ b/src/main/java/io/logz/jmx2graphite/Jmx2GraphiteConfiguration.java
@@ -95,7 +95,7 @@ public class Jmx2GraphiteConfiguration {
 
         graphiteConnectTimeout = config.getInt("graphite.connectTimeout");
         graphiteSocketTimeout = config.getInt("graphite.socketTimeout");
-        graphiteProtocol = GraphiteProtocol.valueOf(config.getString("graphite.protocol"));
+        graphiteProtocol = getGraphiteProtocol(config);
         if (config.hasPath("graphite.writeTimeout")) {
             graphiteWriteTimeoutMs = config.getInt("graphite.writeTimeout");
         } else {
@@ -103,7 +103,13 @@ public class Jmx2GraphiteConfiguration {
         }
     }
 
-
+    private GraphiteProtocol getGraphiteProtocol(Config config) {
+        String protocol = config.getString("graphite.protocol");
+        if (protocol != null) {
+            return GraphiteProtocol.valueOf(protocol.toUpperCase());
+        }
+        return null;
+    }
 
     public String getJolokiaFullUrl() {
         return jolokiaFullUrl;

--- a/src/main/java/io/logz/jmx2graphite/Jmx2GraphiteJavaAgent.java
+++ b/src/main/java/io/logz/jmx2graphite/Jmx2GraphiteJavaAgent.java
@@ -83,6 +83,8 @@ public class Jmx2GraphiteJavaAgent {
                 return "graphite.socketTimeout";
             case "GRAPHITE_WRITE_TIMEOUT_MS":
                 return "graphite.writeTimeout";
+            case "GRAPHITE_PROTOCOL":
+                return "graphite.protocol";
             default:
                 throw new IllegalConfiguration("Unknown configuration option: " + key);
         }

--- a/src/main/java/io/logz/jmx2graphite/MetricsPipeline.java
+++ b/src/main/java/io/logz/jmx2graphite/MetricsPipeline.java
@@ -26,7 +26,8 @@ public class MetricsPipeline {
 
         this.graphiteClient = new GraphiteClient(conf.getServiceHost(), conf.getServiceName(), conf.getGraphiteHostname(),
                                                  conf.getGraphitePort(), conf.getGraphiteConnectTimeout(),
-                                                 conf.getGraphiteSocketTimeout(), conf.getGraphiteWriteTimeoutMs());
+                                                 conf.getGraphiteSocketTimeout(), conf.getGraphiteWriteTimeoutMs(),
+                                                 conf.getGraphiteProtocol());
         this.client = client;
         this.pollingIntervalSeconds = conf.getMetricsPollingIntervalInSeconds();
     }

--- a/src/main/resources/javaagent.conf
+++ b/src/main/resources/javaagent.conf
@@ -19,6 +19,7 @@ service {
 graphite {
   hostname = ${?GRAPHITE_HOST}
   port = ${?GRAPHITE_PORT}
+  protocol = ${?GRAPHITE_PROTOCOL}
 }
 
 metricsPollingIntervalInSeconds = ${?INTERVAL_IN_SEC}

--- a/src/test/java/io/logz/jmx2graphite/TestGraphiteClient.java
+++ b/src/test/java/io/logz/jmx2graphite/TestGraphiteClient.java
@@ -1,15 +1,14 @@
 package io.logz.jmx2graphite;
 
-import com.google.common.collect.Lists;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.junit.Assert.fail;
 
+import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.fail;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author amesika
@@ -39,7 +38,8 @@ public class TestGraphiteClient {
     public void testOnServerShutdown() throws Exception {
         int connectTimeout = 1000;
         int socketTimeout = 1000;
-        GraphiteClient client = new GraphiteClient("bla-host.com", "bla-service", "localhost", port, connectTimeout, socketTimeout, 2000);
+        GraphiteClient client = new GraphiteClient("bla-host.com", "bla-service", "localhost",
+                                                   port, connectTimeout, socketTimeout, 2000, null);
 
         ArrayList<MetricValue> dummyMetrics = Lists.newArrayList(new MetricValue("dice", 4, TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis())));
 
@@ -63,7 +63,9 @@ public class TestGraphiteClient {
     public void testOnServerRestart() throws InterruptedException {
         int connectTimeout = 1000;
         int socketTimeout = 1000;
-        GraphiteClient client = new GraphiteClient("bla-host.com", "bla-service", "localhost", port, connectTimeout, socketTimeout, 20000);
+        GraphiteClient client = new GraphiteClient("bla-host.com", "bla-service", "localhost",
+                                                   port, connectTimeout, socketTimeout, 20000,
+                                                   null);
 
         ArrayList<MetricValue> dummyMetrics = Lists.newArrayList(new MetricValue("dice", 4, TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis())));
 


### PR DESCRIPTION
Add support for udp and tcp Graphite protocol in order to be able to use InfluxDB instead of Graphite. Pickle protocol will continue to be the default protocol since it's better than the others if you use Graphite.

Here is an example of use InfluxDB instead of Graphite:

```
jmx2graphite:
  build: .
  environment:
    - JOLOKIA_URL=http://host:8081/jolokia
    - SERVICE_NAME=MyName
    - GRAPHITE_HOST=influxdb
    - GRAPHITE_PORT=2003
    - GRAPHITE_PROTOCOL=tcp
  links:
    - influxdb
influxdb:
  image: influxdb:1.0.1
  ports:
    - "8086:8086"
    - "8083:8083"
  environment:
    - INFLUXDB_GRAPHITE_ENABLED=true
    - INFLUXDB_GRAPHITE_DATABASE=monitor
grafana:
  image: grafana/grafana:3.1.1
  ports:
    - "3000:3000"
  links:
    - influxdb
```
