### PR TITLE
Updated README.md to update the docker command for running jmx2graphite

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ docker run -i -t -d --name jmx2graphite \
    -e "GRAPHITE_HOST=graphite.foo.com" \
    -e "GRAPHITE_PROTOCOL=pickled" \
    -v /var/log/jmx2graphite:/var/log/jmx2graphite \
-   --rm=true
+   --rm=true \
    logzio/jmx2graphite
 ```
 


### PR DESCRIPTION
The docker command for running jmx2graphite was missing a slash due to which the command was breaking. Now the command has been updated.