### PR TITLE
Fix metric name encode

### DIFF
--- a/src/main/java/io/logz/jmx2graphite/GraphiteClient.java
+++ b/src/main/java/io/logz/jmx2graphite/GraphiteClient.java
@@ -93,7 +93,7 @@ public class GraphiteClient implements Closeable {
         try {
             return URLEncoder.encode(sb.toString(), ENCODING);
         } catch (UnsupportedEncodingException e) {
-            logger.error("Unsupported encoding {}.", ENCODING, e);
+            logger.error("Unsupported encoding {} for metric name {}.", ENCODING, s);
             return sb.toString();
         }
     }

--- a/src/main/java/io/logz/jmx2graphite/GraphiteClient.java
+++ b/src/main/java/io/logz/jmx2graphite/GraphiteClient.java
@@ -15,11 +15,14 @@ import org.slf4j.LoggerFactory;
 import javax.net.SocketFactory;
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketException;
+import java.net.URLEncoder;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static io.logz.jmx2graphite.GraphiteProtocol.TCP;
@@ -28,6 +31,7 @@ import static io.logz.jmx2graphite.GraphiteProtocol.UDP;
 
 public class GraphiteClient implements Closeable {
     private static final Logger logger = LoggerFactory.getLogger(GraphiteClient.class);
+    private static final String ENCODING = StandardCharsets.UTF_8.name();
     private GraphiteSender graphite;
     private String metricsPrefix;
     private int failuresAtLastWrite = 0;
@@ -85,7 +89,13 @@ public class GraphiteClient implements Closeable {
                 sb.append(c);
             }
         }
-        return sb.toString();
+
+        try {
+            return URLEncoder.encode(sb.toString(), ENCODING);
+        } catch (UnsupportedEncodingException e) {
+            logger.error("Unsupported encoding {}.", ENCODING, e);
+            return sb.toString();
+        }
     }
 
     /**

--- a/src/test/java/io/logz/jmx2graphite/GraphiteClientTest.java
+++ b/src/test/java/io/logz/jmx2graphite/GraphiteClientTest.java
@@ -1,5 +1,7 @@
 package io.logz.jmx2graphite;
 
+import static io.logz.jmx2graphite.GraphiteClient.sanitizeMetricName;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.Lists;
@@ -14,9 +16,9 @@ import org.slf4j.LoggerFactory;
  * @author amesika
  *
  */
-public class TestGraphiteClient {
+public class GraphiteClientTest {
 
-    private final static Logger logger = LoggerFactory.getLogger(TestGraphiteClient.class);
+    private final static Logger logger = LoggerFactory.getLogger(GraphiteClientTest.class);
 
     private int port = new Random().nextInt(65000 - 10000) + 10000;
     private DummyGraphiteServer server;
@@ -89,5 +91,14 @@ public class TestGraphiteClient {
             fail("Send metrics failed, this shouldn't happen");
         }
 
+    }
+
+    @Test
+    public void testSanitizeMetricName() {
+        String sanitizedMetricName = sanitizeMetricName("local,project com.zaxxer.hikari type_Pool:334|613-(HikariCP=reader-1).TotalConnections");
+
+        String expectedSanitizedMetricName = "local.project-com.zaxxer.hikari-type_Pool.334%7C613-%28HikariCP_reader-1%29.TotalConnections";
+
+        assertEquals(sanitizedMetricName, expectedSanitizedMetricName);
     }
 }


### PR DESCRIPTION
### **Description**

There is an issue to publish metrics when the metric name contains special characters; this PR is to fix that issue. The best way to fix that is by using URL encoding. The metric name should use URL encoded characters, otherwise, graphite does not show the metric. Graphite shows the error "No Data" if the metric name contains special characters.

### **Error**

The following figure shows the error.

![Screen Shot 2022-01-10 at 5 33 08 AM](https://user-images.githubusercontent.com/1013619/148775375-0ae9b4b4-225c-42c8-bdf9-73c1cea3d80b.png)

Log: _22/01/10 05:33:30 TRACE jmx2graphite.MetricsPipeline: MetricValue{name='com.zaxxer.hikari.type_Pool-(HikariCP-writer-2).TotalConnections', value=5, timestampSeconds=1641772800}_

An easy way to test graphite is by executing the command ``echo "local.jmx.my-project.com.zaxxer.hikari.type_Pool-(HikariCP-reader-1).TotalConnections 5 `date +%s`" | nc ${GRAPHITE_SERVER} ${PORT}``

### **Fix**

Using the URLEncoder (**https://docs.oracle.com/javase/1.5.0/docs/api/java/net/URLEncoder.html**) the error is fixed.

![Screen Shot 2022-01-10 at 5 20 18 AM](https://user-images.githubusercontent.com/1013619/148775391-f0d0aee3-6adf-448b-9ffd-eae5bc50df7b.png)

Log: _22/01/10 05:37:36 TRACE jmx2graphite.MetricsPipeline: MetricValue{name='com.zaxxer.hikari.type_Pool-%28HikariCP-writer-2%29.ActiveConnections', value=0, timestampSeconds=1641772800}_

Command to test graphite ``echo "local.jmx.my-project.com.zaxxer.hikari.type_Pool-%28HikariCP-reader-1%29.TotalConnections 5 `date +%s`" | nc ${GRAPHITE_SERVER} ${PORT}``

### **Additional Information**

The following PRs show the same fix applied to other projects:

https://github.com/grafana/grafana/pull/401
https://github.com/graphite-project/graphite-web/pull/1663

