### PR TITLE
Run CI on forked repo by using Pull Request events triggering it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,10 @@
 name: Build
 
-on: [ push ]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Right now the Build and Test Job runs only upon push to original repository. We want to run it also when someone forks the repository when a pull requests is opened, so the triggering events has changed to support that