### PR TITLE
Fix trigger for Release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,10 +1,8 @@
 name: Release
 
 on:
-  push:
-    # Sequence of patterns matched against refs/tags
-    tags:
-      - '*' # Push events to matching *, i.e. 1.0, 20.15.10
+  release:
+    types: [ published ]
 
 jobs:
   release-github:


### PR DESCRIPTION
Release Workflow should run when I'm publishing a release (from the UI), since the "on push" doesn't work from some reasons