### PR TITLE
Fix metric name sanitization

### DIFF
--- a/src/test/java/io/logz/jmx2graphite/GraphiteClientTest.java
+++ b/src/test/java/io/logz/jmx2graphite/GraphiteClientTest.java
@@ -97,7 +97,7 @@ public class GraphiteClientTest {
     public void testSanitizeMetricName() {
         String sanitizedMetricName = sanitizeMetricName("local,project com.zaxxer.hikari type_Pool:334|613-(HikariCP=reader-1).TotalConnections");
 
-        String expectedSanitizedMetricName = "local.project-com.zaxxer.hikari-type_Pool.334%7C613-%28HikariCP_reader-1%29.TotalConnections";
+        String expectedSanitizedMetricName = "local.project-com.zaxxer.hikari-type_Pool.334_613-_HikariCP_reader-1_.TotalConnections";
 
         assertEquals(sanitizedMetricName, expectedSanitizedMetricName);
     }


### PR DESCRIPTION
Doing a URL encode to the metric name doesn't actually fix the issue with special characters, we actually need to handle Graphite grammar and also normalize the name in the NFKD form. This is what Micrometer does for instance. We also need to make sure that the metric value is in the format that graphite will always understand, and that's why I used the same formatting that Dropwizard Graphite Reporter uses, so it formats float and double in the same way that graphite is expecting them.

We needed that fix to be properly able to export C3P0 and HikariCP metrics to our Graphite system, without those changes the metrics sent to Graphite made us get the following error:

![image](https://user-images.githubusercontent.com/8834774/189228265-f0a32344-a405-4e42-93e0-96fece600547.png)
